### PR TITLE
limit number of total jobs run in Gitlab job and set poolsize to 8

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,7 +59,7 @@ perlmutter_scheduled_test:
     - *setup-buildtest
   script:
     - buildtest buildspec find --rebuild --root $CI_PROJECT_DIR/buildspecs
-    - buildtest build -t $TAGNAME --account m3503_g --testdir $CFS/m3503/buildtest/runs/$CI_JOB_NAME/$(date +%F)
+    - buildtest build -t $TAGNAME --limit 25 --account m3503_g --testdir $CFS/m3503/buildtest/runs/$CI_JOB_NAME/$(date +%F)
     - buildtest report --fail | tee $CI_PROJECT_DIR/.artifacts/report.txt
     - buildtest cdash upload $CDASH_BUILD_NAME
   after_script:
@@ -81,7 +81,7 @@ muller_scheduled_test:
     - *setup-buildtest
   script:
     - buildtest buildspec find --rebuild --root $CI_PROJECT_DIR/buildspecs
-    - buildtest build -t $TAGNAME --account m3503_g --testdir $CFS/m3503/buildtest/runs/$CI_JOB_NAME/$(date +%F)
+    - buildtest build -t $TAGNAME --limit 25 --account m3503_g --testdir $CFS/m3503/buildtest/runs/$CI_JOB_NAME/$(date +%F)
     - buildtest report --fail | tee $CI_PROJECT_DIR/.artifacts/report.txt
     - buildtest cdash upload $CDASH_BUILD_NAME
   after_script:

--- a/config.yml
+++ b/config.yml
@@ -5,6 +5,7 @@ system:
     - login01
     - login02
     moduletool: lmod
+    poolsize: 8
     buildspecs:
       rebuild: false
       count: 15
@@ -145,6 +146,7 @@ system:
     hostnames:
     - login[01-40]
     moduletool: lmod
+    poolsize: 8
     buildspecs:
       rebuild: false
       count: 15


### PR DESCRIPTION
limit poolsize to 8 when using multiprocessing library