### PR TITLE
regenerate all spack based tests for 22.11 

### DIFF
--- a/buildspecs/e4s/spack_test/perlmutter/22.11/aml.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/aml.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   aml_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for aml from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/amrex.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/amrex.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   amrex_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for amrex from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/arborx.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/arborx.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   arborx_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for arborx from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/bolt.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/bolt.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   bolt_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for bolt from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/caliper.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/caliper.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   caliper_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for caliper from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/fortrilinos.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/fortrilinos.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   fortrilinos_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for fortrilinos from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/gasnet.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/gasnet.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   gasnet_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for gasnet from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/ginkgo.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/ginkgo.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   ginkgo_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for ginkgo from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/gptune.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/gptune.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   gptune_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for gptune from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/heffte.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/heffte.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   heffte_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for heffte from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/hpctoolkit.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/hpctoolkit.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   hpctoolkit_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for hpctoolkit from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/kokkos.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/kokkos.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   kokkos_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for kokkos from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/legion.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/legion.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   legion_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for legion from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/mfem.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/mfem.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   mfem_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for mfem from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/omega-h.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/omega-h.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   omega-h_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for omega-h from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/openpmd-api.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/openpmd-api.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   openpmd-api_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for openpmd-api from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/papyrus.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/papyrus.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   papyrus_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for papyrus from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/parallel-netcdf.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/parallel-netcdf.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   parallel-netcdf_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for parallel-netcdf from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/parsec.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/parsec.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   parsec_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for parsec from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/pumi.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/pumi.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   pumi_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for pumi from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/py-h5py.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/py-h5py.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   py-h5py_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for py-h5py from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/py-libensemble.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/py-libensemble.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   py-libensemble_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for py-libensemble from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/py-petsc4py.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/py-petsc4py.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   py-petsc4py_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for py-petsc4py from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/py-warpx.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/py-warpx.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   py-warpx_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for py-warpx from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/qthreads.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/qthreads.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   qthreads_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for qthreads from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/slate.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/slate.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   slate_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for slate from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/slepc.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/slepc.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   slepc_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for slepc from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/sundials.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/sundials.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   sundials_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for sundials from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/superlu.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/superlu.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   superlu_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for superlu from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/tasmanian.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/tasmanian.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   tasmanian_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for tasmanian from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/tau.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/tau.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   tau_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for tau from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/upcxx.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/upcxx.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   upcxx_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for upcxx from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/vtk-m.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/vtk-m.yml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   vtk-m_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for vtk-m from e4s/22.11 gcc stack
     tags: [e4s]

--- a/buildspecs/e4s/testgen/spack-test-22.11-template.yaml
+++ b/buildspecs/e4s/testgen/spack-test-22.11-template.yaml
@@ -1,7 +1,7 @@
 #This buildtest was generated from spack-test-22.11-template.yaml
 buildspecs:
   {package}_spack-test_22.11:
-    type: script
+    type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for {package} from e4s/22.11 gcc stack
     tags: [e4s]


### PR DESCRIPTION
@wspear i noticed all the e4s/22.11 tests using spack test were not valid i fixed them now. It was using `type: script` but rather it should be `type: spack` since that is the schema type for spack based tests. I was able to confirm all files are now valid

```console
(buildtest) siddiq90@login25> buildtest bc validate -b 22.11
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/upcxx.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/slate.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/pumi.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/ginkgo.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/vtk-m.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/aml.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/tasmanian.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/openpmd-api.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/kokkos.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/papyrus.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/sundials.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/mfem.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/caliper.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/py-h5py.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/py-warpx.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/omega-h.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/py-petsc4py.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/hpctoolkit.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/parsec.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/gptune.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/parallel-netcdf.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/amrex.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/legion.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/tau.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/slepc.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/gasnet.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/arborx.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/fortrilinos.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/superlu.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/py-libensemble.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/qthreads.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/heffte.yml is valid
buildspec: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/e4s/spack_test/perlmutter/22.11/bolt.yml is valid
```