### PR TITLE
update tagnames to e4s-22.11

### DIFF
--- a/buildspecs/e4s/spack_test/perlmutter/22.11/aml.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/aml.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for aml from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/amrex.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/amrex.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for amrex from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/arborx.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/arborx.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for arborx from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/bolt.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/bolt.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for bolt from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/caliper.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/caliper.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for caliper from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/fortrilinos.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/fortrilinos.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for fortrilinos from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/gasnet.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/gasnet.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for gasnet from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/ginkgo.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/ginkgo.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for ginkgo from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/gptune.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/gptune.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for gptune from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/heffte.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/heffte.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for heffte from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/hpctoolkit.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/hpctoolkit.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for hpctoolkit from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/kokkos.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/kokkos.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for kokkos from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/legion.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/legion.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for legion from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/mfem.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/mfem.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for mfem from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/omega-h.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/omega-h.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for omega-h from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/openpmd-api.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/openpmd-api.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for openpmd-api from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/papyrus.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/papyrus.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for papyrus from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/parallel-netcdf.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/parallel-netcdf.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for parallel-netcdf from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/parsec.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/parsec.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for parsec from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/pumi.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/pumi.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for pumi from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/py-h5py.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/py-h5py.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for py-h5py from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/py-libensemble.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/py-libensemble.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for py-libensemble from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/py-petsc4py.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/py-petsc4py.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for py-petsc4py from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/py-warpx.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/py-warpx.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for py-warpx from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/qthreads.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/qthreads.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for qthreads from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/slate.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/slate.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for slate from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/slepc.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/slepc.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for slepc from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/sundials.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/sundials.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for sundials from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/superlu.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/superlu.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for superlu from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/tasmanian.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/tasmanian.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for tasmanian from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/tau.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/tau.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for tau from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/upcxx.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/upcxx.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for upcxx from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/spack_test/perlmutter/22.11/vtk-m.yml
+++ b/buildspecs/e4s/spack_test/perlmutter/22.11/vtk-m.yml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for vtk-m from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/testgen/spack-test-22.11-template.yaml
+++ b/buildspecs/e4s/testgen/spack-test-22.11-template.yaml
@@ -4,9 +4,8 @@ buildspecs:
     type: spack
     executor: perlmutter.slurm.regular
     description: Run spack test for {package} from e4s/22.11 gcc stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
-    tags: e4s
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     pre_cmds: |
       module load e4s/22.11
       spack env activate  gcc

--- a/buildspecs/e4s/testgen/testgen.py
+++ b/buildspecs/e4s/testgen/testgen.py
@@ -10,7 +10,12 @@ if len(sys.argv) < 3:
  
 file_path = sys.argv[1]
 package_path = sys.argv[2]
- 
+dest_path = sys.argv[3]
+dest_path = os.path.abspath(dest_path)
+
+if not os.path.isdir(dest_path):
+    exit("ERROR: Provide a valid destination directory. "+dest_path+" not found.")
+
 #check if file is present
 if not os.path.isfile(file_path):
     exit("ERROR: Provide a valid template file. "+file_path+" not found.")
@@ -33,5 +38,6 @@ if template is None or not template.strip():
     exit("ERROR: Empty template file. "+file_path)
 
 for pname in packages["package"]:
-    with open(pname+".yml", "w") as ymlOut:
+    fname = os.path.join(dest_path, pname+".yml")
+    with open(fname, "w") as ymlOut:
         ymlOut.write(template.format(package=pname))


### PR DESCRIPTION
@wspear @etpalmer63 

i updated the testgen.py script to take into account a destination directory so this can be flexible enough to write to desired location. Currently this wrote to current directory.

This PR will also update the timelimit for slurm jobs. 30min seems too little for runtime so i bumped this up to 2hr. I also updated the tagnames to distinguish by e4s versions for now