### PR TITLE
update tagname for E4S Testsuite to e4s-22.11

### DIFF
--- a/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/adios2.yml
+++ b/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/adios2.yml
@@ -4,8 +4,8 @@ buildspecs:
     type: script
     executor: perlmutter.slurm.regular
     description: Run E4S Testsuite adios2 test for e4s/22.11 stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     run: |
       module load e4s/22.11
       module load cpu

--- a/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/butterflypack.yml
+++ b/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/butterflypack.yml
@@ -4,8 +4,8 @@ buildspecs:
     type: script
     executor: perlmutter.slurm.regular
     description: Run E4S Testsuite butterflypack test for e4s/22.11 stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     run: |
       module load e4s/22.11
       module load cpu

--- a/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/dyninst.yml
+++ b/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/dyninst.yml
@@ -4,8 +4,8 @@ buildspecs:
     type: script
     executor: perlmutter.slurm.regular
     description: Run E4S Testsuite dyninst test for e4s/22.11 stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     run: |
       module load e4s/22.11
       module load cpu

--- a/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/gasnet.yml
+++ b/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/gasnet.yml
@@ -4,8 +4,8 @@ buildspecs:
     type: script
     executor: perlmutter.slurm.regular
     description: Run E4S Testsuite gasnet test for e4s/22.11 stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     run: |
       module load e4s/22.11
       module load cpu

--- a/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/hpctoolkit.yml
+++ b/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/hpctoolkit.yml
@@ -4,8 +4,8 @@ buildspecs:
     type: script
     executor: perlmutter.slurm.regular
     description: Run E4S Testsuite hpctoolkit test for e4s/22.11 stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     run: |
       module load e4s/22.11
       module load cpu

--- a/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/kokkos.yml
+++ b/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/kokkos.yml
@@ -4,8 +4,8 @@ buildspecs:
     type: script
     executor: perlmutter.slurm.regular
     description: Run E4S Testsuite kokkos test for e4s/22.11 stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     run: |
       module load e4s/22.11
       module load cpu

--- a/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/qthreads.yml
+++ b/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/qthreads.yml
@@ -4,8 +4,8 @@ buildspecs:
     type: script
     executor: perlmutter.slurm.regular
     description: Run E4S Testsuite qthreads test for e4s/22.11 stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     run: |
       module load e4s/22.11
       module load cpu

--- a/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/strumpack.yml
+++ b/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/strumpack.yml
@@ -4,8 +4,8 @@ buildspecs:
     type: script
     executor: perlmutter.slurm.regular
     description: Run E4S Testsuite strumpack test for e4s/22.11 stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     run: |
       module load e4s/22.11
       module load cpu

--- a/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/superlu-dist.yml
+++ b/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/superlu-dist.yml
@@ -4,8 +4,8 @@ buildspecs:
     type: script
     executor: perlmutter.slurm.regular
     description: Run E4S Testsuite superlu-dist test for e4s/22.11 stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     run: |
       module load e4s/22.11
       module load cpu

--- a/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/superlu.yml
+++ b/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/superlu.yml
@@ -4,8 +4,8 @@ buildspecs:
     type: script
     executor: perlmutter.slurm.regular
     description: Run E4S Testsuite superlu test for e4s/22.11 stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     run: |
       module load e4s/22.11
       module load cpu

--- a/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/tau.yml
+++ b/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/tau.yml
@@ -4,8 +4,8 @@ buildspecs:
     type: script
     executor: perlmutter.slurm.regular
     description: Run E4S Testsuite tau test for e4s/22.11 stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     run: |
       module load e4s/22.11
       module load cpu

--- a/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/trilinos.yml
+++ b/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/trilinos.yml
@@ -4,8 +4,8 @@ buildspecs:
     type: script
     executor: perlmutter.slurm.regular
     description: Run E4S Testsuite trilinos test for e4s/22.11 stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     run: |
       module load e4s/22.11
       module load cpu

--- a/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/vtk-m.yml
+++ b/buildspecs/e4s/E4S-Testsuite/perlmutter/22.11/vtk-m.yml
@@ -4,8 +4,8 @@ buildspecs:
     type: script
     executor: perlmutter.slurm.regular
     description: Run E4S Testsuite vtk-m test for e4s/22.11 stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     run: |
       module load e4s/22.11
       module load cpu

--- a/buildspecs/e4s/testgen/e4s-22.11-template.yaml
+++ b/buildspecs/e4s/testgen/e4s-22.11-template.yaml
@@ -4,8 +4,8 @@ buildspecs:
     type: script
     executor: perlmutter.slurm.regular
     description: Run E4S Testsuite {package} test for e4s/22.11 stack
-    tags: [e4s]
-    sbatch: ["-t 30", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
+    tags: [e4s-22.11]
+    sbatch: ["-t 120", "-N 1", "-G 1", "-A m3503_g", "-C gpu"]
     run: |
       module load e4s/22.11
       module load cpu


### PR DESCRIPTION
@wspear i have updated the e4s testsuite 22.11 tests to use tagname `e4s-22.11` please consider using this convention for tagname for time being until we figure out variable injection mentioned by @etpalmer63 in https://github.com/buildtesters/buildtest/issues/1029#issuecomment-1716082425 