### PR TITLE
fix broken buildspecs for hpctoolkit

### DIFF
--- a/buildspecs/apps/hpctoolkit/hpctoolkit_cuda_vecadd_pc_perlmutter.yml
+++ b/buildspecs/apps/hpctoolkit/hpctoolkit_cuda_vecadd_pc_perlmutter.yml
@@ -35,7 +35,7 @@ buildspecs:
           file: "numrecords.txt"
           exp: '\d+'
     status:
-      mode: "all"
+      mode: "and"
       returncode: 0
       file_count:
       - dir: "hpctoolkit-vecadd.m"

--- a/buildspecs/apps/hpctoolkit/hpctoolkit_cuda_vecadd_perlmutter.yml
+++ b/buildspecs/apps/hpctoolkit/hpctoolkit_cuda_vecadd_perlmutter.yml
@@ -33,7 +33,7 @@ buildspecs:
           file: "numrecords.txt"
           exp: '\d+'
     status:
-      mode: "all"
+      mode: "and"
       returncode: 0
       file_count:
       - dir: "hpctoolkit-vecadd.m"


### PR DESCRIPTION
@wyphan just a heads up, the `mode` property was recently changed so instead of `all` or `any` for logical OR/AND we switched to `and`, `or`. You can also use `AND`/`OR` as well. 