### PR TITLE
redesign CI behavior

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -144,7 +144,7 @@ muller_system_check:
     CDASH_BUILD_NAME: "apps-large"
 
 .apps_mini_test_perlmutter:
-  extends: .apps_min
+  extends: .apps_mini
   tags: [perlmutter-bdtest]
 
 .apps_mini_test_muller:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,3 +104,11 @@ muller_scheduled_test:
       - schedules
     variables:
       - $SYSTEM == "muller"
+
+perlmutter_system_check:
+  extends: .scheduled_test
+  tags: [perlmutter-bdtest]
+  variables:
+    TAGNAME: "system"
+
+  

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,18 +7,25 @@ variables:
   - module load python/3.9-anaconda-2021.11
   - python -m venv $CI_PROJECT_DIR/pyenv
   - source $CI_PROJECT_DIR/pyenv/bin/activate
-  - git clone -b devel https://github.com/buildtesters/buildtest    
-  - cd buildtest 
+  - git clone -b devel https://github.com/buildtesters/buildtest
+  - cd buildtest
   - . setup.sh
   - git log --oneline -1
   - buildtest --help
   - export BUILDTEST_CONFIGFILE=$CI_PROJECT_DIR/config.yml
-  - buildtest config validate    
+  - buildtest config validate
 
 .buildspec_cache: &buildspec_cache
   - buildtest buildspec find --quiet --rebuild --root $CI_PROJECT_DIR/buildspecs
   - buildtest buildspec summary
   - buildtest buildspec find invalid
+
+.post_run: &post_run
+  - mkdir -p $CI_PROJECT_DIR/.artifacts
+  - buildtest report --fail | tee $CI_PROJECT_DIR/.artifacts/report.txt
+  - buildtest cdash upload $CDASH_BUILD_NAME
+  - cp $(buildtest --logpath) $CI_PROJECT_DIR/.artifacts/
+
 stages:
   - check
   - test
@@ -57,12 +64,8 @@ stages:
       else
           buildtest build -t $TAGNAME --limit $LIMIT --account m3503_g --timeout $TIMEOUT --testdir $SCRATCHDIR --executor-type $MODE
       fi
-    #- if [ -z "$MODE" ]; then buildtest build -t $TAGNAME --limit $TESTLIMIT --account m3503_g --timeout $TIMEOUT --testdir $SCRATCHDIR; else buildtest build -t $TAGNAME --limit $TESTLIMIT --account m3503_g --timeout $TIMEOUT --testdir $SCRATCHDIR --executor-type $MODE; fi
-    #- buildtest build -t $TAGNAME --limit $TESTLIMIT --account m3503_g --timeout $TIMEOUT --testdir $SCRATCHDIR
-    - mkdir -p $CI_PROJECT_DIR/.artifacts
-    - buildtest report --fail | tee $CI_PROJECT_DIR/.artifacts/report.txt
-    - buildtest cdash upload $CDASH_BUILD_NAME
-    - cp $(buildtest --logpath) $CI_PROJECT_DIR/.artifacts/
+  after_script:
+    - *post_run
   artifacts:
     paths:
       - $CI_PROJECT_DIR/.artifacts
@@ -84,45 +87,26 @@ test_compilers_muller:
   extends: .test_compilers
   tags: [ muller-bdtest ]
 
-perlmutter_scheduled_test:
-  extends: .scheduled_test
-  tags: [ perlmutter-bdtest ]
-  needs: [validate_buildspecs_on_perlmutter, test_compilers_perlmutter]
-  only:
-    refs:
-      - schedules
-    variables:
-      - $SYSTEM == "perlmutter"
 
-muller_scheduled_test:
+.system_check:
   extends: .scheduled_test
-  tags: [muller-bdtest]
-  needs: [validate_buildspecs_on_muller, test_compilers_muller]
-  only:
-    refs:
-      - schedules
-    variables:
-      - $SYSTEM == "muller"
+  variables:
+    TAGNAME: "system"
+    CDASH_BUILD_NAME: "system-check"
 
 perlmutter_system_check:
-  extends: .scheduled_test
+  extends: .system_check
   tags: [perlmutter-bdtest]
-  variables:
-    TAGNAME: "system"
-    CDASH_BUILD_NAME: "system-check"
 
-  
+
 muller_system_check:
-  extends: .scheduled_test
+  extends: .system_check
   tags: [muller-bdtest]
-  variables:
-    TAGNAME: "system"
-    CDASH_BUILD_NAME: "system-check"
 
 .e4s_test:
   extends: .scheduled_test
   variables:
-    TAGNAME: "e4s"
+    TAGNAME: "e4s,e4s-22.11,e4s-23.05"
 
 .e4s_mini_test:
   extends: .e4s_test
@@ -161,7 +145,7 @@ e4s_mini_test_muller:
 e4s_large_test_muller:
   extends: .e4s_large_test
   tags: [muller-bdtest]
-    
+
 .apps_test:
   extends: .scheduled_test
   only:
@@ -193,3 +177,59 @@ apps_mini_test_muller:
   extends: .apps_mini
   tags: [muller-bdtest]
 
+.full_testsuite:
+  stage: test
+  before_script:
+    - *setup-buildtest
+  script:
+    - buildtest buildspec find --rebuild --root $CI_PROJECT_DIR/buildspecs
+    - TESTDIR=$CI_PROJECT_DIR/buildtest/runs/$CI_JOB_NAME/$(date +%F)
+    - SCRATCHDIR=$PSCRATCH/buildtest/runs/$CI_JOB_NAME/$(date +%F)
+      buildtest build -b buildspecs/ --limit $LIMIT --account m3503_g --timeout $TIMEOUT --testdir $SCRATCHDIR
+  after_script:
+    - *post_run
+  artifacts:
+    paths:
+      - $CI_PROJECT_DIR/.artifacts
+    expire_in: 1 week
+
+.mini_fullsuite:
+  extends: .full_testsuite
+  only:
+    refs:
+      - schedules
+    variables:
+      - $SCHEDULE_TYPE == "mini-fullsuite"
+  variables:
+    LIMIT: 25
+    CDASH_BUILD_NAME: "mini-fullsuite"
+
+
+.large_fullsuite:
+  extends: .full_testsuite
+  only:
+    refs:
+      - schedules
+    variables:
+      - $SCHEDULE_TYPE == "large-fullsuite"
+  variables:
+    LIMIT: 75
+    CDASH_BUILD_NAME: "large-fullsuite"
+
+
+mini-fullsuite-perlmutter:
+  extends: .mini_fullsuite
+  tags: [perlmutter-bdtest]
+
+mini-fullsuite-muller:
+  extends: .mini_fullsuite
+  tags: [muller-bdtest]
+
+
+large-fullsuite-perlmutter:
+  extends: .large_fullsuite
+  tags: [perlmutter-bdtest]
+
+large-fullsuite-muller:
+  extends: .large_fullsuite
+  tags: [muller-bdtest]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,6 +124,6 @@ test_file_changes:
   tags: [perlmutter-bdtest]
   stage: check
   script: 
-    - echo ${CI_MERGE_REQUEST_DIFF_BASE_SHA} ${CI_COMIT_SHA
+    - echo ${CI_MERGE_REQUEST_DIFF_BASE_SHA} ${CI_COMIT_SHA}
     - files=$(git diff-tree -r --diff-filter=d --name-only --no-commit-id ${CI_MERGE_REQUEST_DIFF_BASE_SHA}..${CI_COMIT_SHA} | grep '^buildspecs/' || true)
     - echo $files  

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -125,7 +125,10 @@ test_file_changes:
   stage: check
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"    
+  before_script:
+    *setup-buildtest
   script: 
     - echo ${CI_MERGE_REQUEST_DIFF_BASE_SHA} ${CI_COMIT_SHA}
     - files=$(git diff-tree -r --diff-filter=d --name-only --no-commit-id ${CI_MERGE_REQUEST_DIFF_BASE_SHA}..${CI_COMIT_SHA} | grep '^buildspecs/' || true)
     - echo $files  
+    - if [ -n $files ]; then buildtest buildspec validate -b $files; fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,6 +128,6 @@ test_file_changes:
     *setup-buildtest
   script: 
     - echo ${CI_MERGE_REQUEST_DIFF_BASE_SHA} ${CI_COMMIT_SHA}
-    - files=$(git diff-tree -r --diff-filter=d --name-only --no-commit-id ${CI_MERGE_REQUEST_DIFF_BASE_SHA}..${CI_COMMIT_SHA} | grep '^buildspecs/*.yml' || true)
+    - files=$(git diff-tree -r --diff-filter=d --name-only --no-commit-id ${CI_MERGE_REQUEST_DIFF_BASE_SHA}..${CI_COMMIT_SHA} | grep '^buildspecs/' || true)
     - echo $files  
-    - if [ -n $files ]; then for file in $files; do buildtest build -b $file --maxpendtime=120 --timeout=300; done; fi
+    - if [ -n $files ]; then for file in $files; do buildtest buildspec validate -b $file; done; fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -120,3 +120,34 @@ muller_system_check:
     TAGNAME: "system"
     CDASH_BUILD_NAME: "system-check"
 
+.apps_test:
+  extends: .scheduled_test
+  only:
+    refs:
+      - schedules
+    variables:
+      - $SCHEDULE_TYPE == "apps-mini"
+  variables:
+    TAGNAME: "compile,gpu,mpi,openmp"
+    LIMIT: 25
+
+.apps_mini:
+  extends: .apps_test
+  variables:
+    LIMIT: 25
+    CDASH_BUILD_NAME: "apps-mini"
+
+.apps_large:
+  extends: .apps_test
+  variables:
+    LIMIT: 50
+    CDASH_BUILD_NAME: "apps-large"
+
+.apps_mini_test_perlmutter:
+  extends: .apps_min
+  tags: [perlmutter-bdtest]
+
+.apps_mini_test_muller:
+  extends: .apps_mini
+  tags: [muller-bdtest]
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,7 +128,7 @@ test_file_changes:
   before_script:
     *setup-buildtest
   script: 
-    - echo ${CI_MERGE_REQUEST_DIFF_BASE_SHA} ${CI_COMIT_SHA}
-    - files=$(git diff-tree -r --diff-filter=d --name-only --no-commit-id ${CI_MERGE_REQUEST_DIFF_BASE_SHA}..${CI_COMIT_SHA} | grep '^buildspecs/' || true)
+    - echo ${CI_MERGE_REQUEST_DIFF_BASE_SHA} ${CI_COMMIT_SHA}
+    - files=$(git diff-tree -r --diff-filter=d --name-only --no-commit-id ${CI_MERGE_REQUEST_DIFF_BASE_SHA}..${CI_COMMIT_SHA} | grep '^buildspecs/' || true)
     - echo $files  
     - if [ -n $files ]; then buildtest buildspec validate -b $files; fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,6 +122,8 @@ muller_system_check:
 
 test_file_changes:
   tags: [perlmutter-bdtest]
+  stage: check
   script: 
-    - files=$(git diff-tree -r --diff-filter=d --name-only --no-commit-id ${CI_MERGE_REQUEST_DIFF_BASE_SHA}..${CI_COMIT_SHA} | grep '^buildspecs/')
+    - echo ${CI_MERGE_REQUEST_DIFF_BASE_SHA} ${CI_COMIT_SHA
+    - files=$(git diff-tree -r --diff-filter=d --name-only --no-commit-id ${CI_MERGE_REQUEST_DIFF_BASE_SHA}..${CI_COMIT_SHA} | grep '^buildspecs/' || true)
     - echo $files  

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -113,3 +113,9 @@ perlmutter_system_check:
     CDASH_BUILD_NAME: "system-check"
 
   
+muller_system_check:
+  extends: .scheduled_test
+  tags: [muller-bdtest]
+  variables:
+    TAGNAME: "system"
+    CDASH_BUILD_NAME: "system-check"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -120,14 +120,3 @@ muller_system_check:
     TAGNAME: "system"
     CDASH_BUILD_NAME: "system-check"
 
-test_file_changes:
-  tags: [perlmutter-bdtest]
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event"    
-  before_script:
-    *setup-buildtest
-  script: 
-    - echo ${CI_MERGE_REQUEST_DIFF_BASE_SHA} ${CI_COMMIT_SHA}
-    - files=$(git diff-tree -r --diff-filter=d --name-only --no-commit-id ${CI_MERGE_REQUEST_DIFF_BASE_SHA}..${CI_COMMIT_SHA} | grep '^buildspecs/' || true)
-    - echo $files  
-    - if [ -n $files ]; then for file in $files; do buildtest buildspec validate -b $file; done; fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -143,11 +143,11 @@ muller_system_check:
     LIMIT: 50
     CDASH_BUILD_NAME: "apps-large"
 
-.apps_mini_test_perlmutter:
+apps_mini_test_perlmutter:
   extends: .apps_mini
   tags: [perlmutter-bdtest]
 
-.apps_mini_test_muller:
+apps_mini_test_muller:
   extends: .apps_mini
   tags: [muller-bdtest]
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -125,7 +125,7 @@ muller_system_check:
     refs:
       - schedules
     variables:
-      - $SCHEDULE_TYPE == "e4s-large"
+      - $SCHEDULE_TYPE == "large"
   variables:
     LIMIT: 75
     CDASH_BUILD_NAME: "e4s-large"
@@ -167,7 +167,7 @@ e4s_large_test_muller:
   extends: .apps_test
   variables:
     LIMIT: 50
-    CDASH_BUILD_NAME: "apps-large"
+    CDASH_BUILD_NAME: "large"
 
 apps_mini_test_perlmutter:
   extends: .apps_mini
@@ -210,7 +210,7 @@ apps_mini_test_muller:
     refs:
       - schedules
     variables:
-      - $SCHEDULE_TYPE == "large-fullsuite"
+      - $SCHEDULE_TYPE == "large"
   variables:
     LIMIT: 75
     CDASH_BUILD_NAME: "large-fullsuite"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,7 +52,6 @@ variables:
     - TESTDIR=$CI_PROJECT_DIR/buildtest/runs/$CI_JOB_NAME/$(date +%F)
     - SCRATCHDIR=$PSCRATCH/buildtest/runs/$CI_JOB_NAME/$(date +%F)
     - buildtest build -t $TAGNAME --limit $LIMIT --account m3503_g --timeout $TIMEOUT --testdir $SCRATCHDIR
-  after_script:
     - *post_run
   artifacts:
     paths:
@@ -185,7 +184,6 @@ apps_mini_test_muller:
     - TESTDIR=$CI_PROJECT_DIR/buildtest/runs/$CI_JOB_NAME/$(date +%F)
     - SCRATCHDIR=$PSCRATCH/buildtest/runs/$CI_JOB_NAME/$(date +%F)
     - buildtest build -b $CI_PROJECT_DIR/buildspecs/ --limit $LIMIT --account m3503_g --timeout $TIMEOUT --testdir $SCRATCHDIR
-  after_script:
     - *post_run
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -110,5 +110,6 @@ perlmutter_system_check:
   tags: [perlmutter-bdtest]
   variables:
     TAGNAME: "system"
+    CDASH_BUILD_NAME: "system-check"
 
   

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -123,6 +123,8 @@ muller_system_check:
 test_file_changes:
   tags: [perlmutter-bdtest]
   stage: check
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"    
   script: 
     - echo ${CI_MERGE_REQUEST_DIFF_BASE_SHA} ${CI_COMIT_SHA}
     - files=$(git diff-tree -r --diff-filter=d --name-only --no-commit-id ${CI_MERGE_REQUEST_DIFF_BASE_SHA}..${CI_COMIT_SHA} | grep '^buildspecs/' || true)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,3 +119,9 @@ muller_system_check:
   variables:
     TAGNAME: "system"
     CDASH_BUILD_NAME: "system-check"
+
+test_file_changes:
+  tags: [perlmutter-bdtest]
+  script: 
+    - files=$(git diff-tree -r --diff-filter=d --name-only --no-commit-id ${CI_MERGE_REQUEST_DIFF_BASE_SHA}..${CI_COMIT_SHA} | grep '^buildspecs/')
+    - echo $files  

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,9 +53,9 @@ stages:
     - SCRATCHDIR=$PSCRATCH/buildtest/runs/$CI_JOB_NAME/$(date +%F)
     - |
       if [ -z "$MODE" ]; then
-          buildtest build -t $TAGNAME --limit $TESTLIMIT --account m3503_g --timeout $TIMEOUT --testdir $SCRATCHDIR
+          buildtest build -t $TAGNAME --limit $LIMIT --account m3503_g --timeout $TIMEOUT --testdir $SCRATCHDIR
       else
-          buildtest build -t $TAGNAME --limit $TESTLIMIT --account m3503_g --timeout $TIMEOUT --testdir $SCRATCHDIR --executor-type $MODE
+          buildtest build -t $TAGNAME --limit $LIMIT --account m3503_g --timeout $TIMEOUT --testdir $SCRATCHDIR --executor-type $MODE
       fi
     #- if [ -z "$MODE" ]; then buildtest build -t $TAGNAME --limit $TESTLIMIT --account m3503_g --timeout $TIMEOUT --testdir $SCRATCHDIR; else buildtest build -t $TAGNAME --limit $TESTLIMIT --account m3503_g --timeout $TIMEOUT --testdir $SCRATCHDIR --executor-type $MODE; fi
     #- buildtest build -t $TAGNAME --limit $TESTLIMIT --account m3503_g --timeout $TIMEOUT --testdir $SCRATCHDIR

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,12 +26,7 @@ variables:
   - buildtest cdash upload $CDASH_BUILD_NAME
   - cp $(buildtest --logpath) $CI_PROJECT_DIR/.artifacts/
 
-stages:
-  - check
-  - test
-
 .validate_buildspecs:
-  stage: check
   allow_failure: true
   #rules:
   #  - if: '$CI_PIPELINE_SOURCE == "external_pull_request_event" && $CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME == $CI_DEFAULT_BRANCH'
@@ -41,7 +36,6 @@ stages:
     - *buildspec_cache
 
 .test_compilers:
-  stage: check
   allow_failure: true
   #rules:
   #  - if: '$CI_PIPELINE_SOURCE == "external_pull_request_event" && $CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME == $CI_DEFAULT_BRANCH'
@@ -51,19 +45,13 @@ stages:
     - buildtest config compilers test
 
 .scheduled_test:
-  stage: test
   before_script:
     - *setup-buildtest
   script:
     - buildtest buildspec find --rebuild --root $CI_PROJECT_DIR/buildspecs
     - TESTDIR=$CI_PROJECT_DIR/buildtest/runs/$CI_JOB_NAME/$(date +%F)
     - SCRATCHDIR=$PSCRATCH/buildtest/runs/$CI_JOB_NAME/$(date +%F)
-    - |
-      if [ -z "$MODE" ]; then
-          buildtest build -t $TAGNAME --limit $LIMIT --account m3503_g --timeout $TIMEOUT --testdir $SCRATCHDIR
-      else
-          buildtest build -t $TAGNAME --limit $LIMIT --account m3503_g --timeout $TIMEOUT --testdir $SCRATCHDIR --executor-type $MODE
-      fi
+    - buildtest build -t $TAGNAME --limit $LIMIT --account m3503_g --timeout $TIMEOUT --testdir $SCRATCHDIR
   after_script:
     - *post_run
   artifacts:
@@ -93,7 +81,8 @@ test_compilers_muller:
   variables:
     TAGNAME: "system"
     CDASH_BUILD_NAME: "system-check"
-
+    LIMIT: 25
+      
 perlmutter_system_check:
   extends: .system_check
   tags: [perlmutter-bdtest]
@@ -102,6 +91,8 @@ perlmutter_system_check:
 muller_system_check:
   extends: .system_check
   tags: [muller-bdtest]
+
+#### E4S Jobs #####
 
 .e4s_test:
   extends: .scheduled_test
@@ -146,6 +137,8 @@ e4s_large_test_muller:
   extends: .e4s_large_test
   tags: [muller-bdtest]
 
+#### APPLICATION JOBS ####
+
 .apps_test:
   extends: .scheduled_test
   variables:
@@ -181,6 +174,8 @@ apps_mini_test_perlmutter:
 apps_mini_test_muller:
   extends: .apps_mini
   tags: [muller-bdtest]
+
+#### FULL TESTSUITE RUN JOBS #####
 
 .full_testsuite:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -148,26 +148,31 @@ e4s_large_test_muller:
 
 .apps_test:
   extends: .scheduled_test
-  only:
-    refs:
-      - schedules
-    variables:
-      - $SCHEDULE_TYPE == "apps-mini"
   variables:
     TAGNAME: "compile,gpu,mpi,openmp"
     LIMIT: 25
 
 .apps_mini:
   extends: .apps_test
+  only:
+    refs:
+      - schedules
+    variables:
+      - $SCHEDULE_TYPE == "apps-mini"
   variables:
     LIMIT: 25
     CDASH_BUILD_NAME: "apps-mini"
 
 .apps_large:
   extends: .apps_test
+  only:
+    refs:
+      - schedules
+    variables:
+      - $SCHEDULE_TYPE == "large"
   variables:
-    LIMIT: 50
-    CDASH_BUILD_NAME: "large"
+    LIMIT: 75
+    CDASH_BUILD_NAME: "apps-large"
 
 apps_mini_test_perlmutter:
   extends: .apps_mini

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -182,10 +182,9 @@ apps_mini_test_muller:
   before_script:
     - *setup-buildtest
   script:
-    - buildtest buildspec find --rebuild --root $CI_PROJECT_DIR/buildspecs
     - TESTDIR=$CI_PROJECT_DIR/buildtest/runs/$CI_JOB_NAME/$(date +%F)
     - SCRATCHDIR=$PSCRATCH/buildtest/runs/$CI_JOB_NAME/$(date +%F)
-      buildtest build -b buildspecs/ --limit $LIMIT --account m3503_g --timeout $TIMEOUT --testdir $SCRATCHDIR
+    - buildtest build -b $CI_PROJECT_DIR/buildspecs/ --limit $LIMIT --account m3503_g --timeout $TIMEOUT --testdir $SCRATCHDIR
   after_script:
     - *post_run
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,13 +75,19 @@ test_compilers_muller:
   extends: .test_compilers
   tags: [ muller-bdtest ]
 
+.mini_runs:
+  variables:
+    LIMIT: 10
+
+.large_runs:
+  variables:
+    LIMIT: 75
 
 .system_check:
-  extends: .scheduled_test
+  extends: [.scheduled_test, .mini_runs]
   variables:
     TAGNAME: "system"
     CDASH_BUILD_NAME: "system-check"
-    LIMIT: 25
       
 perlmutter_system_check:
   extends: .system_check
@@ -100,25 +106,23 @@ muller_system_check:
     TAGNAME: "e4s,e4s-22.11,e4s-23.05"
 
 .e4s_mini_test:
-  extends: .e4s_test
+  extends: [.e4s_test, .mini_runs]
   only:
     refs:
       - schedules
     variables:
       - $SCHEDULE_TYPE == "e4s-mini"
   variables:
-    LIMIT: 25
     CDASH_BUILD_NAME: "e4s-mini"
 
 .e4s_large_test:
-  extends: .e4s_test
+  extends: [.e4s_test, .large_runs]
   only:
     refs:
       - schedules
     variables:
       - $SCHEDULE_TYPE == "large"
   variables:
-    LIMIT: 75
     CDASH_BUILD_NAME: "e4s-large"
 
 e4s_mini_test_perlmutter:
@@ -143,28 +147,25 @@ e4s_large_test_muller:
   extends: .scheduled_test
   variables:
     TAGNAME: "compile,gpu,mpi,openmp"
-    LIMIT: 25
 
 .apps_mini:
-  extends: .apps_test
+  extends: [.apps_test, .mini_runs]
   only:
     refs:
       - schedules
     variables:
       - $SCHEDULE_TYPE == "apps-mini"
   variables:
-    LIMIT: 25
     CDASH_BUILD_NAME: "apps-mini"
 
 .apps_large:
-  extends: .apps_test
+  extends: [.apps_test, .large_runs]
   only:
     refs:
       - schedules
     variables:
       - $SCHEDULE_TYPE == "large"
   variables:
-    LIMIT: 75
     CDASH_BUILD_NAME: "apps-large"
 
 apps_mini_test_perlmutter:
@@ -178,7 +179,6 @@ apps_mini_test_muller:
 #### FULL TESTSUITE RUN JOBS #####
 
 .full_testsuite:
-  stage: test
   before_script:
     - *setup-buildtest
   script:
@@ -193,26 +193,24 @@ apps_mini_test_muller:
     expire_in: 1 week
 
 .mini_fullsuite:
-  extends: .full_testsuite
+  extends: [.full_testsuite, .mini_runs]
   only:
     refs:
       - schedules
     variables:
       - $SCHEDULE_TYPE == "mini-fullsuite"
   variables:
-    LIMIT: 25
     CDASH_BUILD_NAME: "mini-fullsuite"
 
 
 .large_fullsuite:
-  extends: .full_testsuite
+  extends: [.full_testsuite, .large_runs]
   only:
     refs:
       - schedules
     variables:
       - $SCHEDULE_TYPE == "large"
   variables:
-    LIMIT: 75
     CDASH_BUILD_NAME: "large-fullsuite"
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,13 +122,12 @@ muller_system_check:
 
 test_file_changes:
   tags: [perlmutter-bdtest]
-  stage: check
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"    
   before_script:
     *setup-buildtest
   script: 
     - echo ${CI_MERGE_REQUEST_DIFF_BASE_SHA} ${CI_COMMIT_SHA}
-    - files=$(git diff-tree -r --diff-filter=d --name-only --no-commit-id ${CI_MERGE_REQUEST_DIFF_BASE_SHA}..${CI_COMMIT_SHA} | grep '^buildspecs/' || true)
+    - files=$(git diff-tree -r --diff-filter=d --name-only --no-commit-id ${CI_MERGE_REQUEST_DIFF_BASE_SHA}..${CI_COMMIT_SHA} | grep '^buildspecs/*.yml' || true)
     - echo $files  
-    - if [ -n $files ]; then buildtest buildspec validate -b $files; fi
+    - if [ -n $files ]; then for file in $files; do buildtest build -b $file --maxpendtime=120 --timeout=300; done; fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,4 @@
 variables:
-  TESTLIMIT: 50 # Set default test limit to 50
   TIMEOUT: 3600 # Set default timeout to 3600 seconds
 
 .setup-buildtest: &setup-buildtest
@@ -120,6 +119,49 @@ muller_system_check:
     TAGNAME: "system"
     CDASH_BUILD_NAME: "system-check"
 
+.e4s_test:
+  extends: .scheduled_test
+  variables:
+    TAGNAME: "e4s"
+
+.e4s_mini_test:
+  extends: .e4s_test
+  only:
+    refs:
+      - schedules
+    variables:
+      - $SCHEDULE_TYPE == "e4s-mini"
+  variables:
+    LIMIT: 25
+    CDASH_BUILD_NAME: "e4s-mini"
+
+.e4s_large_test:
+  extends: .e4s_test
+  only:
+    refs:
+      - schedules
+    variables:
+      - $SCHEDULE_TYPE == "e4s-large"
+  variables:
+    LIMIT: 75
+    CDASH_BUILD_NAME: "e4s-large"
+
+e4s_mini_test_perlmutter:
+  extends: .e4s_mini_test
+  tags: [perlmutter-bdtest]
+
+e4s_large_test_perlmutter:
+  extends: .e4s_large_test
+  tags: [perlmutter-bdtest]
+
+e4s_mini_test_muller:
+  extends: .e4s_mini_test
+  tags: [muller-bdtest]
+
+e4s_large_test_muller:
+  extends: .e4s_large_test
+  tags: [muller-bdtest]
+    
 .apps_test:
   extends: .scheduled_test
   only:

--- a/buildspecs/apps/gpus/gpu_tasks.yml
+++ b/buildspecs/apps/gpus/gpu_tasks.yml
@@ -3,7 +3,7 @@ buildspecs:
     type: script
     executor: '(perlmutter|muller).slurm.regular'
     description: "Run script gpus_for_task with 1 node, 1 GPU with 128 CPUs"
-    tags: [system]
+    tags: [gpu]
     sbatch: ["-C gpu", "-t 60", "-n 1", "--ntasks-per-node=1", "-c 128", "--gpus-per-task=1"]
     run: |
       export SLURM_CPU_BIND="cores"

--- a/buildspecs/apps/spack/spack_directory_checks.yml
+++ b/buildspecs/apps/spack/spack_directory_checks.yml
@@ -3,28 +3,29 @@ buildspecs:
     type: script
     description: Check for production directory paths for spack e4s stack
     executor: '(perlmutter|muller).local.bash'
-    tags: [e4s]
+    tags: [e4s,system]
     run: |
-      ls -ld /global/common/software/spackecp/perlmutter/e4s-{22.11,23.05}/default/spack
+      ls -ld /global/common/software/spackecp/perlmutter/e4s-{22.11,23.05,23.08}/default/spack
       ls -l /global/common/software/spackecp/perlmutter/spack_settings/{compilers.yaml,packages.yaml}
   e4s_spack_settings:
     type: script
     description: Check spack site settings exist for all E4S stacks
     executor: '(perlmutter|muller).local.bash'
-    tags: [e4s]
+    tags: [e4s,system]
     run: | 
-      ls /global/common/software/spackecp/perlmutter/e4s-{22.11,23.05}/default/spack/etc/spack/{config,mirrors,modules}.yaml
+      ls /global/common/software/spackecp/perlmutter/e4s-{22.11,23.05,23.08}/default/spack/etc/spack/{config,mirrors,modules}.yaml
 
   buildcache_directory_check:
     type: script
     description: Check for directory existence for spack buildcache directory
     executor: '(perlmutter|muller).local.bash'
-    tags: [e4s]  
-    run: ls -ld /global/common/software/spackecp/mirrors/perlmutter-e4s-{22.11,23.05}/build_cache
+    tags: [e4s,system]  
+    run: ls -ld /global/common/software/spackecp/mirrors/perlmutter-e4s-{22.11,23.05,23.08}/build_cache
     status:
       is_dir:
         - /global/common/software/spackecp/mirrors/perlmutter-e4s-22.11/build_cache
         - /global/common/software/spackecp/mirrors/perlmutter-e4s-23.05/build_cache
+        - /global/common/software/spackecp/mirrors/perlmutter-e4s-23.08/build_cache
 maintainers:
   - shahzebsiddiqui
 

--- a/buildspecs/benchmarks/osu-benchmark/osu_benchmark.yml
+++ b/buildspecs/benchmarks/osu-benchmark/osu_benchmark.yml
@@ -3,6 +3,7 @@ buildspecs:
     type: script
     executor: '(perlmutter|muller).local.bash'
     description: Install OSU benchmark
+    tags: [benchmark]
     run: |
       module load PrgEnv-gnu
       wget https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-5.9.tar.gz
@@ -16,6 +17,7 @@ buildspecs:
     needs: [install_osu_benchmark]
     executor: '(perlmutter|muller).slurm.regular'
     sbatch: ["-A nstaff_g", "-t 5", "-n 2", "-N 2", "-C gpu"]
+    tags: [benchmark]
     description: Run osu bandwidth test (osu_bw, osu_bibw) on 2 nodes with 2 MPI processes
     run: |
       module load PrgEnv-gnu

--- a/buildspecs/tools/showquota.yml
+++ b/buildspecs/tools/showquota.yml
@@ -3,18 +3,19 @@ buildspecs:
     type: script
     description: run the showquota utility
     executor: '(perlmutter|muller).local.bash'
+    tags: [system]
     run: showquota
   showquota_check_m3503:
     type: script
     description: run the showquota check on m3503 project directory
     executor: '(perlmutter|muller).local.bash'
-    tags: [e4s]
+    tags: [system, e4s]
     run: showquota -N $CFS/m3503
   showquota_check_spackecp:
     type: script
     description: run showquota on /global/common/software/spackecp
     executor: '(perlmutter|muller).local.bash'
-    tags: [e4s]
+    tags: [system, e4s]
     run:  showquota -N /global/common/software/spackecp 
 maintainers:
   - shahzebsiddiqui

--- a/buildspecs/tools/sqs.yml
+++ b/buildspecs/tools/sqs.yml
@@ -2,19 +2,19 @@ buildspecs:
   sqs_help:
     type: script
     executor: '(perlmutter|muller).local.bash'
-    tags: ["daily", "system", "tool", "slurm"]
+    tags: ["system", "tool", "slurm"]
     run: sqs --help
 
   show_running_jobs:
     type: script
     executor: '(perlmutter|muller).local.bash'
-    tags: ["daily", "system", "tool", "slurm"]
+    tags: ["system", "tool", "slurm"]
     run: sqs -r -a
 
   show_jobs_qos:
     type: script
     executor: '(perlmutter|muller).local.bash'
-    tags: ["daily", "system", "tool", "slurm"]
+    tags: ["system", "tool", "slurm"]
     run: sqs -a -q regular,premium
 
 maintainers:

--- a/buildspecs/tools/system_git.yml
+++ b/buildspecs/tools/system_git.yml
@@ -2,7 +2,7 @@ buildspecs:
   git_version:
     type: script
     executor: '(perlmutter|muller).local.bash'
-    tags: [tool, daily]
+    tags: [tool, system]
     description: "Check version of /usr/bin/git"
     run: /usr/bin/git --version    
     status:

--- a/config.yml
+++ b/config.yml
@@ -13,8 +13,6 @@ system:
       count: 25
       terse: false
       format: name,id,state,runtime,returncode
-      latest: true
-      oldest: false
     executors:
       defaults:
         pollinterval: 30
@@ -154,8 +152,6 @@ system:
       count: 25
       terse: false
       format: name,id,state,runtime,returncode
-      latest: true
-      oldest: false
     executors:
       defaults:
         pollinterval: 30


### PR DESCRIPTION
@wspear 
This PR will redesign the CI workflow by running different workloads at scheduled pipelines. Currently, we have the following scheduled pipelines available at https://software.nersc.gov/NERSC/buildtest-nersc/-/pipeline_schedules 

There are 4 pipelines that will run a set of mini testsuites. This mini test suite will limit number of tests to `10` to ensure we get test running quickly. The tests will run on both perlmutter and muller.

![Screenshot 2023-11-22 at 2 01 48 PM](https://github.com/buildtesters/buildtest-nersc/assets/12942230/e157f8e6-37ef-4352-b821-9751bb8408d7)

If you click one of the pipelines such as [this one](https://software.nersc.gov/NERSC/buildtest-nersc/-/pipelines/92972) you will see several tests run in parallel. Shown below is pipeline for Mini Apps test.


![Screenshot 2023-11-22 at 2 03 53 PM](https://github.com/buildtesters/buildtest-nersc/assets/12942230/b4d33362-24ef-476e-ac80-7d3df4a60901)


The `Full Testsuite` run will run all tests by doing `buildtest build -b buildspecs/` but this will be limited to X number of test since we use `--limit` option. All other scheduled pipelines will use tagnames to discover buildspecs which works for most test but given that we have lots of tag names the Full Testsuite allows us to run test that may not run frequently.

On every commit we run two jobs `muller_system_check` and `perlmutter_system_check` which will run `buildtest build -t system` which should be a simple sanity check of system that is limited to 10 test runs. This was done to ensure we can run arbitrary test runs on commit instead of waiting on scheduled pipeline to trigger the runs.


The `Large Runs` scheduled pipeline will have `SCHEDULE_TYPE` set to `large` which will run all the tests in large mode which is set to 75 tests.

![Screenshot 2023-11-22 at 2 08 54 PM](https://github.com/buildtesters/buildtest-nersc/assets/12942230/78b47f69-dce5-410c-91b5-c963af4472a2)

If you run this pipeline manually or wait for scheduled interval see [job](https://software.nersc.gov/NERSC/buildtest-nersc/-/pipelines/92973). Take note I created only one scheduled pipeline to run all of them in large mode, instead of creating multiple scheduled pipelines to trigger each type of job `apps`, `e4s`, `fullsuite`


![Screenshot 2023-11-22 at 2 10 21 PM](https://github.com/buildtesters/buildtest-nersc/assets/12942230/c7e0172f-0e5f-491b-9ae2-a6cbb4c67861)
