### PR TITLE
fix libensemble tests since they were failing

### DIFF
--- a/buildspecs/apps/libensemble/libensemble.yml
+++ b/buildspecs/apps/libensemble/libensemble.yml
@@ -22,7 +22,7 @@ buildspecs:
       PYTHONNOUSERSITE: 1
       SLURM_EXACT: 1
       SLURM_MEM_PER_NODE: 0
-    sbatch: ["-t 15", "-N 2", "-C gpu"]
+    sbatch: ["-t 15", "-N 2", "-C gpu", "-A m3503_g"]
     run: bash ./run_forces_gpu_perlmutter.sh
 
 maintainers:

--- a/buildspecs/apps/libensemble/run_1d_sampling_local_mpi.sh
+++ b/buildspecs/apps/libensemble/run_1d_sampling_local_mpi.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 module load python
-module load spack/e4s-22.05
+module load e4s/23.08
 
-spack env activate -V gcc
+spack env activate gcc
 spack load py-libensemble
-spack load py-mpi4py@3.1.2
+spack load py-mpi4py
 
 python test_1d_sampling.py --comms local --nworkers 4
 srun --ntasks=5 --nodes=1 python test_1d_sampling.py

--- a/buildspecs/apps/libensemble/run_forces_gpu_perlmutter.sh
+++ b/buildspecs/apps/libensemble/run_forces_gpu_perlmutter.sh
@@ -2,10 +2,10 @@
 
 module load python
 module load gpu
-module load spack/e4s-22.05
+module load e4s/23.08
 module load PrgEnv-nvidia
 
-spack env activate -V gcc
+spack env activate gcc
 spack load py-libensemble
 
 cc -O3 -DGPU -fopenmp -mp=gpu -target-accel=$CRAY_ACCEL_TARGET -o forces.x forces.c


### PR DESCRIPTION
@jnavarro @shudson
I noticed the test `test_lib_sbatch_forces_perlmutter`  was failing in https://my.cdash.org/test/110542566 so i tried to fix this. First off we had to change the e4s versions since 22.05 stack was removed so that caused some interesting changes. The second question i had about the GPU test `run_forces_gpu_perlmutter.sh`,  I dont understand why we need `PrgEnv-nvidia` loaded. The py-libensemble package is built with `gcc` compiler not nvhpc. Can you please clarify
```console
(buildtest) siddiq90@login02> buildtest it query -o -e test_lib_sbatch_forces_perlmutter test_libe_simple_inplace
──────────────────────────────────────────────────────────────────────────────────── test_libe_simple_inplace/8a17984d-48ce-486f-ad2c-d488c858db59 ────────────────────────────────────────────────────────────────────────────────────
Executor: muller.slurm.regular
Description: run libEnsemble simple script
State: PASS
Returncode: 0
Runtime: 70.49 sec
Starttime: 2023/12/14 08:14:55
Endtime: 2023/12/14 08:16:26
Command: bash test_libe_simple_inplace_build.sh
Test Script: /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/muller.slurm.regular/libensemble/test_libe_simple_inplace/8a17984d/test_libe_simple_inplace.sh
Build Script: /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/muller.slurm.regular/libensemble/test_libe_simple_inplace/8a17984d/test_libe_simple_inplace_build.sh
Output File: /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/muller.slurm.regular/libensemble/test_libe_simple_inplace/8a17984d/test_libe_simple_inplace.out
Error File: /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/muller.slurm.regular/libensemble/test_libe_simple_inplace/8a17984d/test_libe_simple_inplace.err
Log File: /global/u1/s/siddiq90/gitrepos/buildtest/var/logs/buildtest_m_c6rqtv.log
─────────────────────────────────── Output File: /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/muller.slurm.regular/libensemble/test_libe_simple_inplace/8a17984d/test_libe_simple_inplace.out ───────────────────────────────────

libEnsemble with random sampling has generated enough points

libEnsemble with random sampling has generated enough points

─────────────────────────────────── Error File: /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/muller.slurm.regular/libensemble/test_libe_simple_inplace/8a17984d/test_libe_simple_inplace.err ────────────────────────────────────

The following have been reloaded with a version change:
  1) python/3.9-anaconda-2021.11 => python/3.11

/opt/cray/pe/lmod/lmod/init/bash: line 221: conda: command not found

_______________________________________________________________________________________________________
     The Extreme-Scale Scientific Software Stack (E4S) is accessible via the
Spack package manager.

     In order to access the production stack, you will need to load a spack
environment. Here are some tips to get started:


     'spack env list' - List all Spack environments
     'spack env activate gcc' - Activate the "gcc" Spack environment
     'spack env status' - Display the active Spack environment
     'spack load amrex' - Load the "amrex" Spack package into your user
environment

     For additional support, please refer to the following references:

       NERSC E4S Documentation: https://docs.nersc.gov/applications/e4s/
       E4S Documentation: https://e4s.readthedocs.io
       Spack Documentation: https://spack.readthedocs.io/en/latest/
       Spack Slack: https://spackpm.slack.com


______________________________________________________________________________________________________

------------------ Run completed -------------------
Saving results to file: /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/muller.slurm.regular/libensemble/test_libe_simple_inplace/8a17984d/stage/1d_sampling_history_length=1000_evals=504_workers=4
------------------ Run completed -------------------
Saving results to file: /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/muller.slurm.regular/libensemble/test_libe_simple_inplace/8a17984d/stage/1d_sampling_history_length=1000_evals=504_workers=4
```